### PR TITLE
http_archive add support for tar.xz

### DIFF
--- a/http_archive/http_archive.bzl
+++ b/http_archive/http_archive.bzl
@@ -9,7 +9,7 @@ _FLAGS = {
 
 def _type(ctx: "context") -> str.type:
     typ = value_or(ctx.attrs.type, "tar.gz")
-    if typ not in _FLAGS.keys():
+    if typ not in _FLAGS:
         fail("unsupported `type`: {}".format(typ))
     return typ
 


### PR DESCRIPTION
Adds support for `tar.xz` archives to `http_archive`. The user needs to set the attribute `type = "tar.xz"` to make use of this.
