### PR TITLE
WIP - Pass correct rpath origin setting to linker on Darwin (discussion)

### DIFF
--- a/cxx/preprocessor.bzl
+++ b/cxx/preprocessor.bzl
@@ -171,11 +171,14 @@ def cxx_inherited_preprocessor_infos(first_order_deps: list[Dependency]) -> list
     return filter(None, [x.get(CPreprocessorInfo) for x in first_order_deps])
 
 def cxx_merge_cpreprocessors(ctx: AnalysisContext, own: list[CPreprocessor], xs: list[CPreprocessorInfo]) -> CPreprocessorInfo:
+    return cxx_merge_cpreprocessors_actions(ctx.actions, own, xs)
+
+def cxx_merge_cpreprocessors_actions(actions: AnalysisActions, own: list[CPreprocessor], xs: list[CPreprocessorInfo]) -> CPreprocessorInfo:
     kwargs = {"children": [x.set for x in xs]}
     if own:
         kwargs["value"] = own
     return CPreprocessorInfo(
-        set = ctx.actions.tset(CPreprocessorTSet, **kwargs),
+        set = actions.tset(CPreprocessorTSet, **kwargs),
     )
 
 def _format_include_arg(flag: str, path: cmd_args, compiler_type: str) -> list[cmd_args]:

--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -24,6 +24,9 @@ def _deps_arg():
      from which this rules sources import modules or native linkable rules exporting symbols
      this rules sources call into.
 """),
+        "srcs_deps": attrs.dict(attrs.source(), attrs.list(attrs.source()), default = {}, doc = """
+    Allows to declare dependencies for sources manually, additionally to the dependencies automatically detected.
+        """),
     }
 
 def _compiler_flags_arg():

--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -55,10 +55,34 @@ def _scripts_arg():
         ),
     }
 
+def _external_tools_arg():
+    return {
+        "external_tools": attrs.list(attrs.dep(providers = [RunInfo]), default = [], doc = """
+    External executables called from Haskell compiler during preprocessing or compilation.
+"""),
+    }
+
+def _srcs_envs_arg():
+    return {
+        "srcs_envs": attrs.dict(attrs.source(), attrs.dict(attrs.string(), attrs.arg()), default = {}, doc = """
+    Individual run-time env for each source compilation.
+"""),
+    }
+
+def _use_argsfile_at_link_arg():
+    return {
+        "use_argsfile_at_link": attrs.bool(default = False, doc = """
+    Use response file at linking.
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
     compiler_flags_arg = _compiler_flags_arg,
     exported_linker_flags_arg = _exported_linker_flags_arg,
     scripts_arg = _scripts_arg,
+    external_tools_arg = _external_tools_arg,
+    srcs_envs_arg = _srcs_envs_arg,
+    use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
 )

--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -28,7 +28,7 @@ def _deps_arg():
 
 def _compiler_flags_arg():
     return {
-        "compiler_flags": attrs.list(attrs.string(), default = [], doc = """
+        "compiler_flags": attrs.list(attrs.arg(), default = [], doc = """
     Flags to pass to the Haskell compiler when compiling this rule's sources.
 """),
     }

--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -40,9 +40,22 @@ def _exported_linker_flags_arg():
 """),
     }
 
+def _scripts_arg():
+    return {
+        "_generate_target_metadata": attrs.dep(
+            providers = [RunInfo],
+            default = "prelude//haskell/tools:generate_target_metadata",
+        ),
+        "_ghc_wrapper": attrs.dep(
+            providers = [RunInfo],
+            default = "prelude//haskell/tools:ghc_wrapper",
+        ),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
     compiler_flags_arg = _compiler_flags_arg,
     exported_linker_flags_arg = _exported_linker_flags_arg,
+    scripts_arg = _scripts_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -184,6 +184,16 @@ haskell_library = prelude_rule(
     ),
 )
 
+haskell_toolchain_library = prelude_rule(
+    name = "haskell_toolchain_library",
+    docs  = """
+       Declare a library available as part of the GHC toolchain.
+    """,
+    attrs = {
+    },
+)
+
+
 haskell_prebuilt_library = prelude_rule(
     name = "haskell_prebuilt_library",
     docs = """
@@ -257,4 +267,5 @@ haskell_rules = struct(
     haskell_ide = haskell_ide,
     haskell_library = haskell_library,
     haskell_prebuilt_library = haskell_prebuilt_library,
+    haskell_toolchain_library = haskell_toolchain_library,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -46,6 +46,9 @@ haskell_binary = prelude_rule(
         native_common.link_group_public_deps_label() |
         native_common.link_style() |
         haskell_common.srcs_arg() |
+        haskell_common.external_tools_arg() |
+        haskell_common.srcs_envs_arg () |
+        haskell_common.use_argsfile_at_link_arg () |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
@@ -164,6 +167,9 @@ haskell_library = prelude_rule(
     attrs = (
         # @unsorted-dict-items
         haskell_common.srcs_arg() |
+        haskell_common.external_tools_arg() |
+        haskell_common.srcs_envs_arg() |
+        haskell_common.use_argsfile_at_link_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -48,6 +48,7 @@ haskell_binary = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
+        haskell_common.scripts_arg() |
         buck.platform_deps_arg() |
         {
             "contacts": attrs.list(attrs.string(), default = []),
@@ -165,6 +166,7 @@ haskell_library = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
+        haskell_common.scripts_arg() |
         buck.platform_deps_arg() |
         native_common.link_whole(link_whole_type = attrs.bool(default = False)) |
         native_common.preferred_linkage(preferred_linkage_type = attrs.enum(Linkage.values())) |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -5,26 +5,45 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//utils:arglike.bzl", "ArgLike")
+
 load(
     "@prelude//cxx:preprocessor.bzl",
     "cxx_inherited_preprocessor_infos",
-    "cxx_merge_cpreprocessors",
+    "cxx_merge_cpreprocessors_actions",
 )
 load(
     "@prelude//haskell:library_info.bzl",
+    "HaskellLibraryProvider",
     "HaskellLibraryInfoTSet",
+)
+load(
+    "@prelude//haskell:library_info.bzl",
+    "HaskellLibraryInfo",
+)
+load(
+    "@prelude//haskell:link_info.bzl",
+    "HaskellLinkInfo",
 )
 load(
     "@prelude//haskell:toolchain.bzl",
     "HaskellToolchainInfo",
+    "HaskellToolchainLibrary",
+    "DynamicHaskellPackageDbInfo",
+    "HaskellPackageDbTSet",
 )
 load(
     "@prelude//haskell:util.bzl",
+    "attr_deps",
     "attr_deps_haskell_lib_infos",
     "attr_deps_haskell_link_infos",
+    "attr_deps_haskell_toolchain_libraries",
     "get_artifact_suffix",
+    "get_source_prefixes",
+    "is_haskell_boot",
     "is_haskell_src",
     "output_extensions",
+    "src_to_module_name",
     "srcs_to_pairs",
 )
 load(
@@ -32,27 +51,237 @@ load(
     "LinkStyle",
 )
 load("@prelude//utils:argfile.bzl", "at_argfile")
+load("@prelude//:paths.bzl", "paths")
+load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
+load("@prelude//utils:strings.bzl", "strip_prefix")
+
+CompiledModuleInfo = provider(fields = {
+    "abi": provider_field(Artifact),
+    "interfaces": provider_field(list[Artifact]),
+    # TODO[AH] track this module's package-name/id & package-db instead.
+    "db_deps": provider_field(list[Artifact]),
+})
+
+def _compiled_module_project_as_abi(mod: CompiledModuleInfo) -> cmd_args:
+    return cmd_args(mod.abi)
+
+def _compiled_module_project_as_interfaces(mod: CompiledModuleInfo) -> cmd_args:
+    return cmd_args(mod.interfaces)
+
+def _compiled_module_reduce_as_packagedb_deps(children: list[dict[Artifact, None]], mod: CompiledModuleInfo | None) -> dict[Artifact, None]:
+    # TODO[AH] is there a better way to avoid duplicate package-dbs?
+    #   Using a projection instead would produce duplicates.
+    result = {db: None for db in mod.db_deps} if mod else {}
+    for child in children:
+        result.update(child)
+    return result
+
+CompiledModuleTSet = transitive_set(
+    args_projections = {
+        "abi": _compiled_module_project_as_abi,
+        "interfaces": _compiled_module_project_as_interfaces,
+    },
+    reductions = {
+        "packagedb_deps": _compiled_module_reduce_as_packagedb_deps,
+    },
+)
+
+DynamicCompileResultInfo = provider(fields = {
+    "modules": dict[str, CompiledModuleTSet],
+})
 
 # The type of the return value of the `_compile()` function.
 CompileResultInfo = record(
-    objects = field(Artifact),
-    hi = field(Artifact),
+    objects = field(list[Artifact]),
+    hi = field(list[Artifact]),
     stubs = field(Artifact),
+    hashes = field(list[Artifact]),
     producing_indices = field(bool),
-)
-
-CompileArgsInfo = record(
-    result = field(CompileResultInfo),
-    srcs = field(cmd_args),
-    args_for_cmd = field(cmd_args),
-    args_for_file = field(cmd_args),
+    module_tsets = field(DynamicValue),
 )
 
 PackagesInfo = record(
     exposed_package_args = cmd_args,
     packagedb_args = cmd_args,
     transitive_deps = field(HaskellLibraryInfoTSet),
+    bin_paths = cmd_args,
 )
+
+_Module = record(
+    source = field(Artifact),
+    interfaces = field(list[Artifact]),
+    hash = field(Artifact),
+    objects = field(list[Artifact]),
+    stub_dir = field(Artifact | None),
+    prefix_dir = field(str),
+)
+
+
+def _strip_prefix(prefix, s):
+    stripped = strip_prefix(prefix, s)
+
+    return stripped if stripped != None else s
+
+
+def _modules_by_name(ctx: AnalysisContext, *, sources: list[Artifact], link_style: LinkStyle, enable_profiling: bool, suffix: str) -> dict[str, _Module]:
+    modules = {}
+
+    osuf, hisuf = output_extensions(link_style, enable_profiling)
+
+    for src in sources:
+        bootsuf = ""
+        if is_haskell_boot(src.short_path):
+            bootsuf = "-boot"
+        elif not is_haskell_src(src.short_path):
+            continue
+
+        module_name = src_to_module_name(src.short_path) + bootsuf
+        interface_path = paths.replace_extension(src.short_path, "." + hisuf + bootsuf)
+        interface = ctx.actions.declare_output("mod-" + suffix, interface_path)
+        interfaces = [interface]
+        object_path = paths.replace_extension(src.short_path, "." + osuf + bootsuf)
+        object = ctx.actions.declare_output("mod-" + suffix, object_path)
+        objects = [object]
+        hash = ctx.actions.declare_output("mod-" + suffix, interface_path + ".hash")
+
+        if link_style in [LinkStyle("static"), LinkStyle("static_pic")]:
+            dyn_osuf, dyn_hisuf = output_extensions(LinkStyle("shared"), enable_profiling)
+            interface_path = paths.replace_extension(src.short_path, "." + dyn_hisuf + bootsuf)
+            interface = ctx.actions.declare_output("mod-" + suffix, interface_path)
+            interfaces.append(interface)
+            object_path = paths.replace_extension(src.short_path, "." + dyn_osuf + bootsuf)
+            object = ctx.actions.declare_output("mod-" + suffix, object_path)
+            objects.append(object)
+
+        if bootsuf == "":
+            stub_dir = ctx.actions.declare_output("stub-" + suffix + "-" + module_name, dir=True)
+        else:
+            stub_dir = None
+
+        prefix_dir = "mod-" + suffix
+
+        modules[module_name] = _Module(
+            source = src,
+            interfaces = interfaces,
+            hash = hash,
+            objects = objects,
+            stub_dir = stub_dir,
+            prefix_dir = prefix_dir)
+
+    return modules
+
+def _dynamic_target_metadata_impl(actions, artifacts, dynamic_values, outputs, arg):
+    # Add -package-db and -package/-expose-package flags for each Haskell
+    # library dependency.
+
+    packages_info = get_packages_info2(
+        actions,
+        arg.deps,
+        arg.direct_deps_link_info,
+        arg.haskell_toolchain,
+        arg.haskell_direct_deps_lib_infos,
+        LinkStyle("shared"),
+        specify_pkg_version = False,
+        enable_profiling = False,
+        use_empty_lib = True,
+        for_deps = True,
+        resolved = dynamic_values,
+    )
+    package_flag = _package_flag(arg.haskell_toolchain)
+    ghc_args = cmd_args()
+    ghc_args.add("-hide-all-packages")
+    ghc_args.add(package_flag, "base")
+
+    ghc_args.add(cmd_args(arg.toolchain_libs, prepend=package_flag))
+    ghc_args.add(cmd_args(packages_info.exposed_package_args))
+    ghc_args.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
+    ghc_args.add(arg.compiler_flags)
+
+    md_args = cmd_args(arg.md_gen)
+    md_args.add(packages_info.bin_paths)
+    md_args.add("--ghc", arg.haskell_toolchain.compiler)
+    md_args.add(cmd_args(ghc_args, format="--ghc-arg={}"))
+    md_args.add(
+        "--source-prefix",
+        arg.strip_prefix,
+    )
+    md_args.add(cmd_args(arg.sources, format="--source={}"))
+
+    md_args.add(
+        arg.lib_package_name_and_prefix,
+    )
+    md_args.add("--output", outputs[arg.md_file].as_output())
+
+    actions.run(md_args, category = "haskell_metadata", identifier = arg.suffix if arg.suffix else None)
+
+    return []
+
+_dynamic_target_metadata = dynamic_actions(impl = _dynamic_target_metadata_impl)
+
+def target_metadata(
+        ctx: AnalysisContext,
+        *,
+        sources: list[Artifact],
+        suffix: str = "",
+    ) -> Artifact:
+    md_file = ctx.actions.declare_output(ctx.attrs.name + suffix + ".md.json")
+    md_gen = ctx.attrs._generate_target_metadata[RunInfo]
+
+    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
+    toolchain_libs = [dep.name for dep in attr_deps_haskell_toolchain_libraries(ctx)]
+
+    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
+        ctx,
+        LinkStyle("shared"),
+        enable_profiling = False,
+    )
+
+    # The object and interface file paths are depending on the real module name
+    # as inferred by GHC, not the source file path; currently this requires the
+    # module name to correspond to the source file path as otherwise GHC will
+    # not be able to find the created object or interface files in the search
+    # path.
+    #
+    # (module X.Y.Z must be defined in a file at X/Y/Z.hs)
+
+    ctx.actions.dynamic_output_new(_dynamic_target_metadata(
+        dynamic = [],
+        dynamic_values = [haskell_toolchain.packages.dynamic] if haskell_toolchain.packages else [],
+        outputs = [md_file.as_output()],
+        arg = struct(
+            compiler_flags = ctx.attrs.compiler_flags,
+            deps = ctx.attrs.deps,
+            direct_deps_link_info = attr_deps_haskell_link_infos(ctx),
+            haskell_direct_deps_lib_infos = haskell_direct_deps_lib_infos,
+            haskell_toolchain = haskell_toolchain,
+            lib_package_name_and_prefix =_attr_deps_haskell_lib_package_name_and_prefix(ctx),
+            md_file = md_file,
+            md_gen = md_gen,
+            sources = sources,
+            strip_prefix = _strip_prefix(str(ctx.label.cell_root), str(ctx.label.path)),
+            suffix = suffix,
+            toolchain_libs = toolchain_libs,
+        ),
+    ))
+
+    return md_file
+
+def _attr_deps_haskell_lib_package_name_and_prefix(ctx: AnalysisContext) -> cmd_args:
+    args = cmd_args(prepend = "--package")
+
+    for dep in attr_deps(ctx) + ctx.attrs.template_deps:
+        lib = dep.get(HaskellLibraryProvider)
+        if lib == None:
+            continue
+
+        lib_info = lib.lib.values()[0]
+        args.add(cmd_args(
+            lib_info.name,
+            cmd_args(lib_info.db, parent = 1),
+            delimiter = ":",
+        ))
+
+    return args
 
 def _package_flag(toolchain: HaskellToolchainInfo) -> str:
     if toolchain.support_expose_package:
@@ -64,13 +293,45 @@ def get_packages_info(
         ctx: AnalysisContext,
         link_style: LinkStyle,
         specify_pkg_version: bool,
-        enable_profiling: bool) -> PackagesInfo:
+        enable_profiling: bool,
+        use_empty_lib: bool) -> PackagesInfo:
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
+
+    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
+        ctx,
+        link_style,
+        enable_profiling,
+    )
+
+    return get_packages_info2(
+        actions = ctx.actions,
+        deps = [],
+        direct_deps_link_info = attr_deps_haskell_link_infos(ctx),
+        haskell_toolchain = haskell_toolchain,
+        haskell_direct_deps_lib_infos = haskell_direct_deps_lib_infos,
+        link_style = link_style,
+        specify_pkg_version = specify_pkg_version,
+        enable_profiling = enable_profiling,
+        use_empty_lib = use_empty_lib,
+        resolved = {},
+    )
+
+def get_packages_info2(
+    actions: AnalysisActions,
+    deps: list[Dependency],
+    direct_deps_link_info: list[HaskellLinkInfo],
+    haskell_toolchain: HaskellToolchainInfo,
+    haskell_direct_deps_lib_infos: list[HaskellLibraryInfo],
+    link_style: LinkStyle,
+    specify_pkg_version: bool,
+    enable_profiling: bool,
+    use_empty_lib: bool,
+    resolved: dict[DynamicValue, ResolvedDynamicValue],
+    for_deps: bool = False) -> PackagesInfo:
 
     # Collect library dependencies. Note that these don't need to be in a
     # particular order.
-    direct_deps_link_info = attr_deps_haskell_link_infos(ctx)
-    libs = ctx.actions.tset(
+    libs = actions.tset(
         HaskellLibraryInfoTSet,
         children = [
             lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
@@ -80,13 +341,21 @@ def get_packages_info(
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
+
     exposed_package_args = cmd_args([package_flag, "base"])
+
+    if for_deps:
+        get_db = lambda l: l.deps_db
+    elif use_empty_lib:
+        get_db = lambda l: l.empty_db
+    else:
+        get_db = lambda l: l.db
 
     packagedb_args = cmd_args()
     packagedb_set = {}
 
     for lib in libs.traverse():
-        packagedb_set[lib.db] = None
+        packagedb_set[get_db(lib)] = None
         hidden_args = cmd_args(hidden = [
             lib.import_dirs.values(),
             lib.stub_dirs,
@@ -94,20 +363,36 @@ def get_packages_info(
             # we're using Template Haskell:
             lib.libs,
         ])
-
         exposed_package_args.add(hidden_args)
-
         packagedb_args.add(hidden_args)
+
+    if resolved:
+        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
+        package_db = pkg_deps.providers[DynamicHaskellPackageDbInfo].packages
+    else:
+        package_db = {}
+
+    direct_toolchain_libs = [
+        dep[HaskellToolchainLibrary].name
+        for dep in deps
+        if HaskellToolchainLibrary in dep
+    ]
+
+    toolchain_libs = direct_toolchain_libs + libs.reduce("packages")
+
+    package_db_tset = actions.tset(
+        HaskellPackageDbTSet,
+        children = [package_db[name] for name in toolchain_libs if name in package_db]
+    )
 
     # These we need to add for all the packages/dependencies, i.e.
     # direct and transitive (e.g. `fbcode-common-hs-util-hs-array`)
-    packagedb_args.add([cmd_args("-package-db", x) for x in packagedb_set])
+    packagedb_args.add(packagedb_set.keys())
 
-    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
-        ctx,
-        link_style,
-        enable_profiling,
-    )
+    packagedb_args.add(package_db_tset.project_as_args("package_db"))
+
+    direct_package_paths = [package_db[name].value.path for name in direct_toolchain_libs if name in package_db]
+    bin_paths = cmd_args(direct_package_paths, format="--bin-path={}/bin")
 
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:
@@ -121,146 +406,484 @@ def get_packages_info(
         exposed_package_args = exposed_package_args,
         packagedb_args = packagedb_args,
         transitive_deps = libs,
+        bin_paths = bin_paths,
     )
 
-def compile_args(
-        ctx: AnalysisContext,
-        link_style: LinkStyle,
-        enable_profiling: bool,
-        pkgname = None,
-        suffix: str = "") -> CompileArgsInfo:
-    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
+CommonCompileModuleArgs = record(
+    command = field(cmd_args),
+    args_for_file = field(cmd_args),
+    package_env_args = field(cmd_args),
+)
 
-    compile_cmd = cmd_args()
-    compile_cmd.add(haskell_toolchain.compiler_flags)
+def _common_compile_module_args(
+    actions: AnalysisActions,
+    *,
+    compiler_flags: list[ArgLike],
+    ghc_wrapper: RunInfo,
+    haskell_toolchain: HaskellToolchainInfo,
+    resolved: dict[DynamicValue, ResolvedDynamicValue],
+    enable_haddock: bool,
+    enable_profiling: bool,
+    link_style: LinkStyle,
+    main: None | str,
+    label: Label,
+    deps: list[Dependency],
+    external_tool_paths: list[RunInfo],
+    sources: list[Artifact],
+    direct_deps_info: list[HaskellLibraryInfoTSet],
+    pkgname: str | None = None,
+) -> CommonCompileModuleArgs:
+    command = cmd_args(ghc_wrapper)
+    command.add("--ghc", haskell_toolchain.compiler)
 
     # Some rules pass in RTS (e.g. `+RTS ... -RTS`) options for GHC, which can't
     # be parsed when inside an argsfile.
-    compile_cmd.add(ctx.attrs.compiler_flags)
+    command.add(haskell_toolchain.compiler_flags)
+    command.add(compiler_flags)
 
-    compile_args = cmd_args()
-    compile_args.add("-no-link", "-i")
+    command.add("-c")
+
+    if main != None:
+        command.add(["-main-is", main])
+
+    if enable_haddock:
+        command.add("-haddock")
+
+    non_haskell_sources = [
+        src
+        for (path, src) in srcs_to_pairs(sources)
+        if not is_haskell_src(path) and not is_haskell_boot(path)
+    ]
+
+    if non_haskell_sources:
+        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(label))
+
+    args_for_file = cmd_args(hidden = non_haskell_sources)
+
+    args_for_file.add("-no-link", "-i")
+    args_for_file.add("-hide-all-packages")
 
     if enable_profiling:
-        compile_args.add("-prof")
+        args_for_file.add("-prof")
 
     if link_style == LinkStyle("shared"):
-        compile_args.add("-dynamic", "-fPIC")
+        args_for_file.add("-dynamic", "-fPIC")
     elif link_style == LinkStyle("static_pic"):
-        compile_args.add("-fPIC", "-fexternal-dynamic-refs")
+        args_for_file.add("-fPIC", "-fexternal-dynamic-refs")
 
     osuf, hisuf = output_extensions(link_style, enable_profiling)
-    compile_args.add("-osuf", osuf, "-hisuf", hisuf)
+    args_for_file.add("-osuf", osuf, "-hisuf", hisuf)
 
-    if getattr(ctx.attrs, "main", None) != None:
-        compile_args.add(["-main-is", ctx.attrs.main])
+    # Add args from preprocess-able inputs.
+    inherited_pre = cxx_inherited_preprocessor_infos(deps)
+    pre = cxx_merge_cpreprocessors_actions(actions, [], inherited_pre)
+    pre_args = pre.set.project_as_args("args")
+    args_for_file.add(cmd_args(pre_args, format = "-optP={}"))
 
-    artifact_suffix = get_artifact_suffix(link_style, enable_profiling, suffix)
-
-    objects = ctx.actions.declare_output(
-        "objects-" + artifact_suffix,
-        dir = True,
-    )
-    hi = ctx.actions.declare_output("hi-" + artifact_suffix, dir = True)
-    stubs = ctx.actions.declare_output("stubs-" + artifact_suffix, dir = True)
-
-    compile_args.add(
-        "-odir",
-        objects.as_output(),
-        "-hidir",
-        hi.as_output(),
-        "-hiedir",
-        hi.as_output(),
-        "-stubdir",
-        stubs.as_output(),
-    )
+    if pkgname:
+        args_for_file.add(["-this-unit-id", pkgname])
 
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
-    packages_info = get_packages_info(
-        ctx,
-        link_style,
-        specify_pkg_version = False,
-        enable_profiling = enable_profiling,
+
+    libs = actions.tset(HaskellLibraryInfoTSet, children = direct_deps_info)
+
+    direct_toolchain_libs = [
+        dep[HaskellToolchainLibrary].name
+        for dep in deps
+        if HaskellToolchainLibrary in dep
+    ]
+    toolchain_libs = direct_toolchain_libs + libs.reduce("packages")
+
+    if haskell_toolchain.packages:
+        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
+        package_db = pkg_deps.providers[DynamicHaskellPackageDbInfo].packages
+    else:
+        package_db = []
+
+    package_db_tset = actions.tset(
+        HaskellPackageDbTSet,
+        children = [package_db[name] for name in toolchain_libs if name in package_db]
     )
 
-    compile_args.add(packages_info.exposed_package_args)
-    compile_args.add(packages_info.packagedb_args)
+    direct_package_paths = [package_db[name].value.path for name in direct_toolchain_libs if name in package_db]
+    args_for_file.add(cmd_args(
+        direct_package_paths,
+        format="--bin-path={}/bin",
+    ))
 
-    # Add args from preprocess-able inputs.
-    inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
-    pre = cxx_merge_cpreprocessors(ctx, [], inherited_pre)
-    pre_args = pre.set.project_as_args("args")
-    compile_args.add(cmd_args(pre_args, format = "-optP={}"))
+    args_for_file.add(cmd_args(
+        external_tool_paths,
+        format="--bin-exe={}",
+    ))
 
-    if pkgname:
-        compile_args.add(["-this-unit-id", pkgname])
+    packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
+    packagedb_args.add(package_db_tset.project_as_args("package_db"))
 
-    arg_srcs = []
-    hidden_srcs = []
+    # TODO[AH] Avoid duplicates and share identical env files.
+    #   The set of package-dbs can be known at the package level, not just the
+    #   module level. So, we could generate this file outside of the
+    #   dynamic_output action.
+    package_env_file = actions.declare_output(".".join([
+        label.name,
+        "package-db",
+        output_extensions(link_style, enable_profiling)[1],
+        "env",
+    ]))
+    package_env = cmd_args(delimiter = "\n")
+    package_env.add(cmd_args(
+        packagedb_args,
+        format = "package-db {}",
+    ).relative_to(package_env_file, parent = 1))
+    actions.write(
+        package_env_file,
+        package_env,
+    )
+    package_env_args = cmd_args(
+        package_env_file,
+        prepend = "-package-env",
+        hidden = packagedb_args,
+    )
 
-    aux_deps = ctx.attrs.srcs_deps.get(module.source)
-    if aux_deps:
-        hidden_srcs(aux_deps)
+    return CommonCompileModuleArgs(
+        command = command,
+        args_for_file = args_for_file,
+        package_env_args = package_env_args,
+    )
 
-    for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
-        # hs-boot files aren't expected to be an argument to compiler but does need
-        # to be included in the directory of the associated src file
-        if is_haskell_src(path):
-            arg_srcs.append(src)
+def _compile_module(
+    actions: AnalysisActions,
+    *,
+    common_args: CommonCompileModuleArgs,
+    link_style: LinkStyle,
+    enable_profiling: bool,
+    enable_th: bool,
+    haskell_toolchain: HaskellToolchainInfo,
+    label: Label,
+    module_name: str,
+    module: _Module,
+    module_tsets: dict[str, CompiledModuleTSet],
+    md_file: Artifact,
+    graph: dict[str, list[str]],
+    package_deps: dict[str, list[str]],
+    outputs: dict[Artifact, Artifact],
+    artifact_suffix: str,
+    direct_deps_by_name: dict[str, typing.Any],
+    toolchain_deps_by_name: dict[str, None],
+    aux_deps: None | list[Artifact],
+    src_envs: None | dict[str, ArgLike],
+    source_prefixes: list[str],
+) -> CompiledModuleTSet:
+    # These compiler arguments can be passed in a response file.
+    compile_args_for_file = cmd_args(common_args.args_for_file, hidden = aux_deps or [])
+
+    packagedb_tag = actions.artifact_tag()
+    compile_args_for_file.add(packagedb_tag.tag_artifacts(common_args.package_env_args))
+
+    dep_file = actions.declare_output(".".join([
+        label.name,
+        module_name or "pkg",
+        "package-db",
+        output_extensions(link_style, enable_profiling)[1],
+        "dep",
+    ])).as_output()
+    tagged_dep_file = packagedb_tag.tag_artifacts(dep_file)
+    compile_args_for_file.add("--buck2-packagedb-dep", tagged_dep_file)
+
+    objects = [outputs[obj] for obj in module.objects]
+    his = [outputs[hi] for hi in module.interfaces]
+
+    compile_args_for_file.add("-o", objects[0].as_output())
+    compile_args_for_file.add("-ohi", his[0].as_output())
+
+    # Set the output directories. We do not use the -outputdir flag, but set the directories individually.
+    # Note, the -outputdir option is shorthand for the combination of -odir, -hidir, -hiedir, -stubdir and -dumpdir.
+    # But setting -hidir effectively disables the use of the search path to look up interface files,
+    # as ghc exclusively looks in that directory when it is set.
+    for dir in ["o", "hie", "dump"]:
+        compile_args_for_file.add(
+           "-{}dir".format(dir), cmd_args([cmd_args(md_file, ignore_artifacts=True, parent=1), module.prefix_dir], delimiter="/"),
+        )
+    if module.stub_dir != None:
+        stubs = outputs[module.stub_dir]
+        compile_args_for_file.add("-stubdir", stubs.as_output())
+
+    if link_style in [LinkStyle("static_pic"), LinkStyle("static")]:
+        compile_args_for_file.add("-dynamic-too")
+        compile_args_for_file.add("-dyno", objects[1].as_output())
+        compile_args_for_file.add("-dynohi", his[1].as_output())
+
+    compile_args_for_file.add(module.source)
+
+    abi_tag = actions.artifact_tag()
+
+    toolchain_deps = []
+    library_deps = []
+    exposed_package_modules = []
+    exposed_package_dbs = []
+    for dep_pkgname, dep_modules in package_deps.items():
+        if dep_pkgname in toolchain_deps_by_name:
+            toolchain_deps.append(dep_pkgname)
+        elif dep_pkgname in direct_deps_by_name:
+            library_deps.append(dep_pkgname)
+            exposed_package_dbs.append(direct_deps_by_name[dep_pkgname].package_db)
+            for dep_modname in dep_modules:
+                exposed_package_modules.append(direct_deps_by_name[dep_pkgname].modules[dep_modname])
         else:
-            hidden_srcs.append(src)
-    srcs = cmd_args(
-        arg_srcs,
-        hidden = hidden_srcs,
+            fail("Unknown library dependency '{}'. Add the library to the `deps` attribute".format(dep_pkgname))
+
+    # Transitive module dependencies from other packages.
+    cross_package_modules = actions.tset(
+        CompiledModuleTSet,
+        children = exposed_package_modules,
+    )
+    # Transitive module dependencies from the same package.
+    this_package_modules = [
+        module_tsets[dep_name]
+        for dep_name in graph[module_name]
+    ]
+
+    dependency_modules = actions.tset(
+        CompiledModuleTSet,
+        children = [cross_package_modules] + this_package_modules,
     )
 
-    producing_indices = "-fwrite-ide-info" in ctx.attrs.compiler_flags
+    compile_cmd_args = [common_args.command]
+    compile_cmd_hidden = [
+        abi_tag.tag_artifacts(dependency_modules.project_as_args("interfaces")),
+        dependency_modules.project_as_args("abi"),
+    ]
+    if src_envs:
+        for k, v in src_envs.items():
+            compile_args_for_file.add(cmd_args(
+                k,
+                format="--extra-env-key={}",
+            ))
+            compile_args_for_file.add(cmd_args(
+                v,
+                format="--extra-env-value={}",
+            ))
+    if haskell_toolchain.use_argsfile:
+        compile_cmd_args.append(at_argfile(
+            actions = actions,
+            name = "haskell_compile_" + artifact_suffix + ".argsfile",
+            args = compile_args_for_file,
+            allow_args = True,
+        ))
+    else:
+        compile_cmd_args.append(compile_args_for_file)
 
-    return CompileArgsInfo(
-        result = CompileResultInfo(
-            objects = objects,
-            hi = hi,
-            stubs = stubs,
-            producing_indices = producing_indices,
+    compile_cmd = cmd_args(compile_cmd_args, hidden = compile_cmd_hidden)
+
+    # add each module dir prefix to search path
+    for prefix in source_prefixes:
+        compile_cmd.add(
+            cmd_args(
+                cmd_args(md_file, format = "-i{}", ignore_artifacts=True, parent=1),
+                "/",
+                paths.join(module.prefix_dir, prefix),
+                delimiter=""
+            )
+        )
+
+
+    compile_cmd.add(cmd_args(library_deps, prepend = "-package"))
+    compile_cmd.add(cmd_args(toolchain_deps, prepend = "-package"))
+
+    compile_cmd.add("-fbyte-code-and-object-code")
+    if enable_th:
+        compile_cmd.add("-fprefer-byte-code")
+
+    compile_cmd.add(cmd_args(dependency_modules.reduce("packagedb_deps").keys(), prepend = "--buck2-package-db"))
+
+    dep_file = actions.declare_output("dep-{}_{}".format(module_name, artifact_suffix)).as_output()
+
+    tagged_dep_file = abi_tag.tag_artifacts(dep_file)
+
+    compile_cmd.add("--buck2-dep", tagged_dep_file)
+    compile_cmd.add("--abi-out", outputs[module.hash].as_output())
+
+    actions.run(
+        compile_cmd, category = "haskell_compile_" + artifact_suffix.replace("-", "_"), identifier = module_name,
+        dep_files = {
+            "abi": abi_tag,
+            "packagedb": packagedb_tag,
+        }
+    )
+
+    module_tset = actions.tset(
+        CompiledModuleTSet,
+        value = CompiledModuleInfo(
+            abi = module.hash,
+            interfaces = module.interfaces,
+            db_deps = exposed_package_dbs,
         ),
-        srcs = srcs,
-        args_for_cmd = compile_cmd,
-        args_for_file = compile_args,
+        children = [cross_package_modules] + this_package_modules,
     )
+
+    return module_tset
+
+def _dynamic_do_compile_impl(actions, artifacts, dynamic_values, outputs, arg):
+    direct_deps_by_name = {
+        info.value.name: struct(
+            package_db = info.value.empty_db,
+            modules = dynamic_values[info.value.dynamic[arg.enable_profiling]].providers[DynamicCompileResultInfo].modules,
+        )
+        for info in arg.direct_deps_info
+    }
+    common_args = _common_compile_module_args(
+        actions,
+        compiler_flags = arg.compiler_flags,
+        deps = arg.deps,
+        external_tool_paths = arg.external_tool_paths,
+        ghc_wrapper = arg.ghc_wrapper,
+        haskell_toolchain = arg.haskell_toolchain,
+        label = arg.label,
+        main = arg.main,
+        resolved = dynamic_values,
+        sources = arg.sources,
+        enable_haddock = arg.enable_haddock,
+        enable_profiling = arg.enable_profiling,
+        link_style = arg.link_style,
+        direct_deps_info = arg.direct_deps_info,
+        pkgname = arg.pkgname,
+    )
+
+    md = artifacts[arg.md_file].read_json()
+    th_modules = md["th_modules"]
+    module_map = md["module_mapping"]
+    graph = md["module_graph"]
+    package_deps = md["package_deps"]
+
+    mapped_modules = { module_map.get(k, k): v for k, v in arg.modules.items() }
+    module_tsets = {}
+    source_prefixes = get_source_prefixes(arg.sources, module_map)
+
+    for module_name in post_order_traversal(graph):
+        module = mapped_modules[module_name]
+        module_tsets[module_name] = _compile_module(
+            actions,
+            aux_deps = arg.sources_deps.get(module.source),
+            src_envs = arg.srcs_envs.get(module.source),
+            common_args = common_args,
+            link_style = arg.link_style,
+            enable_profiling = arg.enable_profiling,
+            enable_th = module_name in th_modules,
+            haskell_toolchain = arg.haskell_toolchain,
+            label = arg.label,
+            module_name = module_name,
+            module = module,
+            module_tsets = module_tsets,
+            graph = graph,
+            package_deps = package_deps.get(module_name, {}),
+            outputs = outputs,
+            md_file = arg.md_file,
+            artifact_suffix = arg.artifact_suffix,
+            direct_deps_by_name = direct_deps_by_name,
+            toolchain_deps_by_name = arg.toolchain_deps_by_name,
+            source_prefixes = source_prefixes,
+        )
+
+    return [DynamicCompileResultInfo(modules = module_tsets)]
+
+
+
+_dynamic_do_compile = dynamic_actions(impl = _dynamic_do_compile_impl)
 
 # Compile all the context's sources.
 def compile(
         ctx: AnalysisContext,
         link_style: LinkStyle,
         enable_profiling: bool,
+        enable_haddock: bool,
+        md_file: Artifact,
         pkgname: str | None = None) -> CompileResultInfo:
+    artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
+
+    modules = _modules_by_name(ctx, sources = ctx.attrs.srcs, link_style = link_style, enable_profiling = enable_profiling, suffix = artifact_suffix)
+
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-    compile_cmd = cmd_args(haskell_toolchain.compiler)
 
-    args = compile_args(ctx, link_style, enable_profiling, pkgname)
+    interfaces = [interface for module in modules.values() for interface in module.interfaces]
+    objects = [object for module in modules.values() for object in module.objects]
+    stub_dirs = [
+        module.stub_dir
+        for module in modules.values()
+        if module.stub_dir != None
+    ]
+    abi_hashes = [module.hash for module in modules.values()]
 
-    compile_cmd.add(args.args_for_cmd)
+    # Collect library dependencies. Note that these don't need to be in a
+    # particular order.
+    toolchain_deps_by_name = {
+        lib.name: None
+        for lib in attr_deps_haskell_toolchain_libraries(ctx)
+    }
+    direct_deps_info = [
+        lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
+        for lib in attr_deps_haskell_link_infos(ctx)
+    ]
 
-    artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
+    dyn_module_tsets = ctx.actions.dynamic_output_new(_dynamic_do_compile(
+        dynamic = [md_file],
+        dynamic_values = [
+            info.value.dynamic[enable_profiling]
+            for lib in attr_deps_haskell_link_infos(ctx)
+            for info in [
+                lib.prof_info[link_style]
+                if enable_profiling else
+                lib.info[link_style]
+            ]
+        ] + ([ haskell_toolchain.packages.dynamic ] if haskell_toolchain.packages else [ ]),
+        outputs = [o.as_output() for o in interfaces + objects + stub_dirs + abi_hashes],
+        arg = struct(
+            artifact_suffix = artifact_suffix,
+            compiler_flags = ctx.attrs.compiler_flags,
+            deps = ctx.attrs.deps,
+            direct_deps_info = direct_deps_info,
+            enable_haddock = enable_haddock,
+            enable_profiling = enable_profiling,
+            external_tool_paths = [tool[RunInfo] for tool in ctx.attrs.external_tools],
+            ghc_wrapper = ctx.attrs._ghc_wrapper[RunInfo],
+            haskell_toolchain = haskell_toolchain,
+            label = ctx.label,
+            link_style = link_style,
+            main = getattr(ctx.attrs, "main", None),
+            md_file = md_file,
+            modules = modules,
+            pkgname = pkgname,
+            sources = ctx.attrs.srcs,
+            sources_deps = ctx.attrs.srcs_deps,
+            srcs_envs = ctx.attrs.srcs_envs,
+            toolchain_deps_by_name = toolchain_deps_by_name,
+        ),
+    ))
 
-    if args.args_for_file:
-        if haskell_toolchain.use_argsfile:
-            compile_cmd.add(at_argfile(
-                actions = ctx.actions,
-                name = artifact_suffix + ".haskell_compile_argsfile",
-                args = [args.args_for_file, args.srcs],
-                allow_args = True,
-            ))
-        else:
-            compile_cmd.add(args.args_for_file)
-            compile_cmd.add(args.srcs)
+    stubs_dir = ctx.actions.declare_output("stubs-" + artifact_suffix, dir=True)
 
-    artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
+    # collect the stubs from all modules into the stubs_dir
     ctx.actions.run(
-        compile_cmd,
-        category = "haskell_compile_" + artifact_suffix.replace("-", "_"),
-        no_outputs_cleanup = True,
+        cmd_args([
+            "bash", "-exuc",
+            """\
+            mkdir -p \"$0\"
+            for stub; do
+              find \"$stub\" -mindepth 1 -maxdepth 1 -exec cp -r -t \"$0\" '{}' ';'
+            done
+            """,
+            stubs_dir.as_output(),
+            stub_dirs
+        ]),
+        category = "haskell_stubs",
+        identifier = artifact_suffix,
+        local_only = True,
     )
 
-    return args.result
+    return CompileResultInfo(
+        objects = objects,
+        hi = interfaces,
+        hashes = abi_hashes,
+        stubs = stubs_dir,
+        producing_indices = False,
+        module_tsets = dyn_module_tsets,
+    )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -198,6 +198,11 @@ def compile_args(
 
     arg_srcs = []
     hidden_srcs = []
+
+    aux_deps = ctx.attrs.srcs_deps.get(module.source)
+    if aux_deps:
+        hidden_srcs(aux_deps)
+
     for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
         # hs-boot files aren't expected to be an argument to compiler but does need
         # to be included in the directory of the associated src file

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -168,6 +168,11 @@ def _attr_preferred_linkage(ctx: AnalysisContext) -> Linkage:
 
 # --
 
+def haskell_toolchain_library_impl(ctx: AnalysisContext):
+    return [DefaultInfo(), HaskellToolchainLibrary(name = ctx.attrs.name)]
+
+# --
+
 def _get_haskell_prebuilt_libs(
         ctx,
         link_style: LinkStyle,

--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -58,6 +58,10 @@ load(
 )
 load("@prelude//linking:types.bzl", "Linkage")
 load(
+    "@prelude//cxx:linker.bzl",
+    "get_rpath_origin",
+)
+load(
     "@prelude//utils:graph_utils.bzl",
     "depth_first_traversal",
     "depth_first_traversal_by",
@@ -304,7 +308,7 @@ def _build_haskell_omnibus_so(ctx: AnalysisContext) -> HaskellOmnibusData:
     soname = "libghci_dependencies.so"
     extra_ldflags = [
         "-rpath",
-        "$ORIGIN/{}".format(so_symlinks_root_path),
+        "{}/{}".format(get_rpath_origin(linker_info.type), so_symlinks_root_path)
     ]
     link_result = cxx_link_shared_library(
         ctx,

--- a/haskell/ide/ide.bxl
+++ b/haskell/ide/ide.bxl
@@ -7,7 +7,8 @@
 
 load("@prelude//haskell:library_info.bzl", "HaskellLibraryProvider")
 load("@prelude//haskell:link_info.bzl", "HaskellLinkInfo")
-load("@prelude//haskell:toolchain.bzl", "HaskellToolchainInfo")
+load("@prelude//haskell:toolchain.bzl", "HaskellToolchainInfo", "HaskellToolchainLibrary")
+load("@prelude//haskell:util.bzl", "is_haskell_src", "srcs_to_pairs")
 load("@prelude//linking:link_info.bzl", "LinkStyle")
 load("@prelude//paths.bzl", "paths")
 
@@ -142,12 +143,19 @@ def _solution_for_haskell_lib(ctx, target, exclude):
     hli = ctx.analysis(target).providers().get(HaskellLibraryProvider)
 
     haskellLibs = {}
+    toolchain_libs = []
+
     for dep in resolved_attrs.deps + resolved_attrs.template_deps:
         if exclude.get(dep.label) == None:
             providers = ctx.analysis(dep.label).providers()
             lb = providers.get(HaskellLinkInfo)
             if lb != None:
                 haskellLibs[dep.label] = lb
+                continue
+
+            lb = providers.get(HaskellToolchainLibrary)
+            if lb != None:
+                toolchain_libs.append(lb.name)
 
     sources = []
     for item in ctx.output.ensure_multiple(resolved_attrs.srcs.values()):
@@ -193,6 +201,7 @@ def _solution_for_haskell_lib(ctx, target, exclude):
         "flags": flags,
         "generated_dependencies": externalSourcesForTarget(ctx, target),
         "haskell_deps": haskellLibs,
+        "toolchain_libs": toolchain_libs,
         "import_dirs": import_dirs.keys(),
         "sources": sources,
         "targets": targetsForTarget(ctx, target),
@@ -269,6 +278,9 @@ def _assembleSolution(ctx, linkStyle, result):
         ctx.output.ensure_multiple(hli.libs)
         ctx.output.ensure_multiple(hli.import_dirs.values())
         package_dbs[hli.db] = ()
+    for lib in result["toolchain_libs"]:
+        flags.append("-package")
+        flags.append(lib)
     for pkgdb in ctx.output.ensure_multiple(package_dbs.keys()):
         flags.append("-package-db")
         flags.append(pkgdb.abs_path())

--- a/haskell/ide/ide.bxl
+++ b/haskell/ide/ide.bxl
@@ -173,11 +173,6 @@ def _solution_for_haskell_lib(ctx, target, exclude):
     haskell_toolchain = ctx.analysis(resolved_attrs._haskell_toolchain.label)
     toolchain = haskell_toolchain.providers().get(HaskellToolchainInfo)
 
-    binutils_path = paths.join(root, toolchain.ghci_binutils_path)
-    cc_path = paths.join(root, toolchain.ghci_cc_path)
-    cxx_path = paths.join(root, toolchain.ghci_cxx_path)
-    cpp_path = paths.join(root, toolchain.ghci_cpp_path)
-
     flags = [
         "-this-unit-id",
         "fbcode_fake_unit_id",
@@ -187,13 +182,31 @@ def _solution_for_haskell_lib(ctx, target, exclude):
         "-no-global-package-db",
         "-no-user-package-db",
         "-hide-all-packages",
-        "-pgma%s" % cc_path,
-        "-pgml%s" % cxx_path,
-        "-pgmc%s" % cc_path,
-        "-pgmP%s" % cpp_path,
-        "-opta-B%s" % binutils_path,
-        "-optc-B%s" % binutils_path,
+        "-i",
     ]
+
+    if toolchain.ghci_binutils_path:
+        binutils_path = paths.join(root, toolchain.ghci_binutils_path)
+        flags.extend([
+            "-opta-B%s" % binutils_path,
+            "-optc-B%s" % binutils_path,
+        ])
+
+    if toolchain.ghci_cc_path:
+        cc_path = paths.join(root, toolchain.ghci_cc_path)
+        flags.extend([
+            "-pgma%s" % cc_path,
+            "-pgmc%s" % cc_path,
+        ])
+
+    if toolchain.ghci_cxx_path:
+        cxx_path = paths.join(root, toolchain.ghci_cxx_path)
+        flags.append("-pgml%s" % cxx_path)
+
+    if toolchain.ghci_cpp_path:
+        cpp_path = paths.join(root, toolchain.ghci_cpp_path)
+        flags.append("-pgmP%s" % cpp_path)
+
     flags.extend(resolved_attrs.compiler_flags)
 
     return {

--- a/haskell/library_info.bzl
+++ b/haskell/library_info.bzl
@@ -5,6 +5,8 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//utils:utils.bzl", "flatten", "dedupe_by_value")
+
 # If the target is a haskell library, the HaskellLibraryProvider
 # contains its HaskellLibraryInfo. (in contrast to a HaskellLinkInfo,
 # which contains the HaskellLibraryInfo for all the transitive
@@ -23,10 +25,18 @@ HaskellLibraryInfo = record(
     name = str,
     # package config database: e.g. platform009/build/ghc/lib/package.conf.d
     db = Artifact,
+    # package config database, referring to the empty lib which is only used for compilation
+    empty_db = Artifact,
+    # pacakge config database, used for ghc -M
+    deps_db = Artifact,
     # e.g. "base-4.13.0.0"
     id = str,
+    # dynamic dependency information
+    dynamic = None | dict[bool, DynamicValue],
     # Import dirs indexed by profiling enabled/disabled
-    import_dirs = dict[bool, Artifact],
+    import_dirs = dict[bool, list[Artifact]],
+    # Object files indexed by profiling enabled/disabled
+    objects = dict[bool, list[Artifact]],
     stub_dirs = list[Artifact],
 
     # This field is only used as hidden inputs to compilation, to
@@ -40,6 +50,32 @@ HaskellLibraryInfo = record(
     version = str,
     is_prebuilt = bool,
     profiling_enabled = bool,
+    # Package dependencies
+    dependencies = list[str],
 )
 
-HaskellLibraryInfoTSet = transitive_set()
+def _project_as_package_db(lib: HaskellLibraryInfo):
+  return cmd_args(lib.db)
+
+def _project_as_empty_package_db(lib: HaskellLibraryInfo):
+  return cmd_args(lib.empty_db)
+
+def _project_as_deps_package_db(lib: HaskellLibraryInfo):
+  return cmd_args(lib.deps_db)
+
+def _get_package_deps(children: list[list[str]], lib: HaskellLibraryInfo | None):
+    flatted = flatten(children)
+    if lib:
+        flatted.extend(lib.dependencies)
+    return dedupe_by_value(flatted)
+
+HaskellLibraryInfoTSet = transitive_set(
+    args_projections = {
+        "package_db": _project_as_package_db,
+        "empty_package_db": _project_as_empty_package_db,
+        "deps_package_db": _project_as_deps_package_db,
+    },
+    reductions = {
+        "packages": _get_package_deps,
+    },
+)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -39,3 +39,9 @@ HaskellToolchainInfo = provider(
         "script_template_processor": provider_field(typing.Any, default = None),
     },
 )
+
+HaskellToolchainLibrary = provider(
+    fields = {
+        "name": provider_field(str),
+    },
+)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -5,6 +5,8 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//utils:arglike.bzl", "ArgLike")
+
 HaskellPlatformInfo = provider(fields = {
     "name": provider_field(typing.Any, default = None),
 })
@@ -37,6 +39,7 @@ HaskellToolchainInfo = provider(
         "ghci_packager": provider_field(typing.Any, default = None),
         "cache_links": provider_field(typing.Any, default = None),
         "script_template_processor": provider_field(typing.Any, default = None),
+        "packages": provider_field(typing.Any, default = None),
     },
 )
 
@@ -45,3 +48,25 @@ HaskellToolchainLibrary = provider(
         "name": provider_field(str),
     },
 )
+
+HaskellPackagesInfo = record(
+    dynamic = DynamicValue,
+)
+
+HaskellPackage = record(
+    db = ArgLike,
+    path = Artifact,
+)
+
+def _haskell_package_info_as_package_db(p: HaskellPackage):
+    return cmd_args(p.db)
+
+HaskellPackageDbTSet = transitive_set(
+    args_projections = {
+        "package_db": _haskell_package_info_as_package_db,
+    }
+)
+
+DynamicHaskellPackageDbInfo = provider(fields = {
+    "packages": dict[str, HaskellPackageDbTSet],
+})

--- a/haskell/tools/BUCK.v2
+++ b/haskell/tools/BUCK.v2
@@ -11,3 +11,15 @@ prelude.python_bootstrap_binary(
     main = "script_template_processor.py",
     visibility = ["PUBLIC"],
 )
+
+prelude.python_bootstrap_binary(
+    name = "generate_target_metadata",
+    main = "generate_target_metadata.py",
+    visibility = ["PUBLIC"],
+)
+
+prelude.python_bootstrap_binary(
+    name = "ghc_wrapper",
+    main = "ghc_wrapper.py",
+    visibility = ["PUBLIC"],
+)

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+"""Helper script to generate relevant metadata about Haskell targets.
+
+* The mapping from module source file to actual module name.
+* The intra-package module dependency graph.
+* The cross-package module dependencies.
+* Which modules require Template Haskell.
+
+Note, boot files will be represented by a `-boot` suffix in the module name.
+
+The result is a JSON object with the following fields:
+* `th_modules`: List of modules that require Template Haskell.
+* `module_mapping`: Mapping from source inferred module name to actual module name, if different.
+* `module_graph`: Intra-package module dependencies, `dict[modname, list[modname]]`.
+* `package_deps`": Cross-package module dependencies, `dict[modname, dict[pkgname, list[modname]]`.
+"""
+
+import argparse
+import sys
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        fromfile_prefix_chars="@")
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=argparse.FileType("w"),
+        help="Write package metadata to this file in JSON format.")
+    parser.add_argument(
+        "--ghc",
+        required=True,
+        type=str,
+        help="Path to the Haskell compiler GHC.")
+    parser.add_argument(
+        "--ghc-arg",
+        required=False,
+        type=str,
+        action="append",
+        help="GHC compiler argument to forward to `ghc -M`, including package flags.")
+    parser.add_argument(
+        "--source-prefix",
+        required=True,
+        type=str,
+        help="The path prefix to strip of module sources to extract module names.")
+    parser.add_argument(
+        "--source",
+        required=True,
+        type=str,
+        action="append",
+        help="Haskell module source files of the current package.")
+    parser.add_argument(
+        "--package",
+        required=False,
+        type=str,
+        action="append",
+        default=[],
+        help="Package dependencies formated as `NAME:PREFIX_PATH`.")
+    parser.add_argument(
+        "--bin-path",
+        type=Path,
+        action="append",
+        default=[],
+        help="Add given path to PATH.",
+    )
+    args = parser.parse_args()
+
+    result = obtain_target_metadata(args)
+
+    json.dump(result, args.output, indent=4, default=json_default_handler)
+
+
+def json_default_handler(o):
+    if isinstance(o, set):
+        return sorted(o)
+    raise TypeError(f'Object of type {o.__class__.__name__} is not JSON serializable')
+
+
+def obtain_target_metadata(args):
+    paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
+    ghc_depends = run_ghc_depends(args.ghc, args.ghc_arg, args.source, paths)
+    th_modules = determine_th_modules(ghc_depends)
+    module_mapping = determine_module_mapping(ghc_depends, args.source_prefix)
+    module_graph = determine_module_graph(ghc_depends)
+    package_deps = determine_package_deps(ghc_depends)
+    return {
+        "th_modules": th_modules,
+        "module_mapping": module_mapping,
+        "module_graph": module_graph,
+        "package_deps": package_deps,
+    }
+
+
+def load_toolchain_packages(filepath):
+    with open(filepath, "r") as f:
+        return json.load(f)
+
+
+def determine_th_modules(ghc_depends):
+    return [
+        modname
+        for modname, properties in ghc_depends.items()
+        if uses_th(properties.get("options", []))
+    ]
+
+
+__TH_EXTENSIONS = ["TemplateHaskell", "TemplateHaskellQuotes", "QuasiQuotes"]
+
+
+def uses_th(opts):
+    """Determine if a Template Haskell extension is enabled."""
+    return any([f"-X{ext}" in opts for ext in __TH_EXTENSIONS])
+
+
+def determine_module_mapping(ghc_depends, source_prefix):
+    result = {}
+
+    for modname, properties in ghc_depends.items():
+        sources = list(filter(is_haskell_src, properties.get("sources", [])))
+
+        if len(sources) != 1:
+            raise RuntimeError(f"Expected exactly one Haskell source for module '{modname}' but got '{sources}'.")
+
+        apparent_name = src_to_module_name(strip_prefix_(source_prefix, sources[0]).lstrip("/"))
+
+        if apparent_name != modname:
+            result[apparent_name] = modname
+
+        boot_properties = properties.get("boot", None)
+        if boot_properties != None:
+            boot_modname = modname + "-boot"
+            boot_sources = list(filter(is_haskell_boot, boot_properties.get("sources", [])))
+
+            if len(boot_sources) != 1:
+                raise RuntimeError(f"Expected at most one Haskell boot file for module '{modname}' but got '{boot_sources}'.")
+
+            boot_apparent_name = src_to_module_name(strip_prefix_(source_prefix, sources[0]).lstrip("/")) + "-boot"
+
+            if boot_apparent_name != boot_modname:
+                result[boot_apparent_name] = boot_modname
+
+    return result
+
+
+def determine_module_graph(ghc_depends):
+    module_deps = {}
+    for modname, description in ghc_depends.items():
+        module_deps[modname] = description.get("modules", []) + [
+            dep + "-boot"
+            for dep in description.get("modules-boot", [])
+        ]
+
+        boot_description = description.get("boot", None)
+        if boot_description != None:
+            module_deps[modname + "-boot"] = boot_description.get("modules", []) + [
+                dep + "-boot"
+                for dep in boot_description.get("modules-boot", [])
+            ]
+
+    return module_deps
+
+
+def determine_package_deps(ghc_depends):
+    package_deps = {}
+
+    for modname, description in ghc_depends.items():
+        for pkgdep in description.get("packages", {}):
+            pkgname = pkgdep.get("name")
+            package_deps.setdefault(modname, {})[pkgname] = pkgdep.get("modules", [])
+
+        boot_description = description.get("boot", None)
+        if boot_description != None:
+            for pkgdep in boot_description.get("packages", {}):
+                pkgname = pkgdep.get("name")
+                package_deps.setdefault(modname + "-boot", {})[pkgname] = pkgdep.get("modules", [])
+
+    return package_deps
+
+
+def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
+    with tempfile.TemporaryDirectory() as dname:
+        json_fname = os.path.join(dname, "depends.json")
+        make_fname = os.path.join(dname, "depends.make")
+        haskell_sources = list(filter(is_haskell_src, sources))
+        args = [
+            ghc, "-M", "-include-pkg-deps",
+            # Note: `-outputdir '.'` removes the prefix of all targets:
+            #       backend/src/Foo/Util.<ext> => Foo/Util.<ext>
+            "-outputdir", ".",
+            "-dep-json", json_fname,
+            "-dep-makefile", make_fname,
+        ] + ghc_args + haskell_sources
+
+        env = os.environ.copy()
+        path = env.get("PATH", "")
+        env["PATH"] = os.pathsep.join([path] + aux_paths)
+
+        res = subprocess.run(args, env=env, capture_output=True)
+        if res.returncode != 0:
+            # Write the GHC command on failure.
+            print(shlex.join(args), file=sys.stderr)
+
+        # Always forward stdout/stderr.
+        # Note, Buck2 swallows stdout on successful builds.
+        # Redirect to stderr to avoid this.
+        sys.stderr.buffer.write(res.stdout)
+        sys.stderr.buffer.write(res.stderr)
+
+        if res.returncode != 0:
+            # Fail if GHC failed.
+            sys.exit(res.returncode)
+
+        with open(json_fname) as f:
+            return json.load(f)
+
+
+def src_to_module_name(x):
+    base, _ = os.path.splitext(x)
+    return base.replace("/", ".")
+
+
+def is_haskell_src(x):
+    _, ext = os.path.splitext(x)
+    return ext in HASKELL_EXTENSIONS
+
+
+def is_haskell_boot(x):
+    _, ext = os.path.splitext(x)
+    return ext in HASKELL_BOOT_EXTENSIONS
+
+
+HASKELL_EXTENSIONS = [
+    ".hs",
+    ".lhs",
+    ".hsc",
+    ".chs",
+    ".x",
+    ".y",
+]
+
+
+HASKELL_BOOT_EXTENSIONS = [
+    ".hs-boot",
+    ".lhs-boot",
+]
+
+
+def strip_prefix_(prefix, s):
+    stripped = strip_prefix(prefix, s)
+
+    if stripped == None:
+        return s
+
+    return stripped
+
+
+def strip_prefix(prefix, s):
+    if s.startswith(prefix):
+        return s[len(prefix):]
+
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+"""Wrapper script to call ghc.
+
+It accepts a dep file where all used inputs are written to. For any passed ABI
+hash file, the corresponding interface is marked as unused, so these can change
+without triggering compilation actions.
+
+"""
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, add_help=False, fromfile_prefix_chars="@"
+    )
+    parser.add_argument(
+        "--buck2-dep",
+        required=True,
+        help="Path to the dep file.",
+    )
+    parser.add_argument(
+        "--buck2-packagedb-dep",
+        required=True,
+        help="Path to the dep file.",
+    )
+    parser.add_argument(
+        "--buck2-package-db",
+        required=False,
+        nargs="*",
+        default=[],
+        help="Path to a package db that is used during the module compilation",
+    )
+    parser.add_argument(
+        "--ghc", required=True, type=str, help="Path to the Haskell compiler GHC."
+    )
+    parser.add_argument(
+        "--abi-out",
+        required=True,
+        type=Path,
+        help="Output path of the abi file to create.",
+    )
+    parser.add_argument(
+        "--bin-path",
+        type=Path,
+        action="append",
+        default=[],
+        help="Add given path to PATH.",
+    )
+    parser.add_argument(
+        "--bin-exe",
+        type=Path,
+        action="append",
+        default=[],
+        help="Add given exe (more specific than bin-path)",
+    )
+    parser.add_argument(
+        "--extra-env-key",
+        type=str,
+        action="append",
+        default=[],
+        help="Extra environment variable name",
+    )
+    parser.add_argument(
+        "--extra-env-value",
+        type=str,
+        action="append",
+        default=[],
+        help="Extra environment variable value",
+    )
+
+    args, ghc_args = parser.parse_known_args()
+
+    cmd = [args.ghc] + ghc_args
+
+    aux_paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()] + [str(os.path.dirname(binexepath)) for binexepath in args.bin_exe]
+    env = os.environ.copy()
+    path = env.get("PATH", "")
+    env["PATH"] = os.pathsep.join([path] + aux_paths)
+
+    extra_env_keys = [str(k) for k in args.extra_env_key]
+    extra_env_values = [str(v) for v in args.extra_env_value]
+    assert len(extra_env_keys) == len(extra_env_values), "number of --extra-env-key and --extra-env-value flags must match"
+    n_extra_env = len(extra_env_keys)
+    if n_extra_env > 0:
+        for i in range(0, n_extra_env):
+            k = extra_env_keys[i]
+            v = extra_env_values[i]
+            env[k] = v
+
+    # Note, Buck2 swallows stdout on successful builds.
+    # Redirect to stderr to avoid this.
+    returncode = subprocess.call(cmd, env=env, stdout=sys.stderr.buffer)
+    if returncode != 0:
+        return returncode
+
+    recompute_abi_hash(args.ghc, args.abi_out)
+
+    # write an empty dep file, to signal that all tagged files are unused
+    try:
+        with open(args.buck2_dep, "w") as f:
+            f.write("\n")
+
+    except Exception as e:
+        # remove incomplete dep file
+        os.remove(args.buck2_dep)
+        raise e
+
+    # write an empty dep file, to signal that all tagged files are unused
+    try:
+        with open(args.buck2_packagedb_dep, "w") as f:
+            for db in args.buck2_package_db:
+                f.write(db + "\n")
+            if not args.buck2_package_db:
+                f.write("\n")
+
+    except Exception as e:
+        # remove incomplete dep file
+        os.remove(args.buck2_packagedb_dep)
+        raise e
+
+    return 0
+
+
+def recompute_abi_hash(ghc, abi_out):
+    """Call ghc on the hi file and write the ABI hash to abi_out."""
+    hi_file = abi_out.with_suffix("")
+
+    cmd = [ghc, "-v0", "-package-env=-", "--show-iface-abi-hash", hi_file]
+
+    hash = subprocess.check_output(cmd, text=True).split(maxsplit=1)[0]
+
+    abi_out.write_text(hash)
+
+
+if __name__ == "__main__":
+    main()

--- a/haskell/tools/script_template_processor.py
+++ b/haskell/tools/script_template_processor.py
@@ -68,16 +68,24 @@ def _replace_template_values(
 
     # user_ghci_path has to be handled separately because it needs to be passed
     # with the ghci_lib_path as the `-B` argument.
-    ghci_lib_canonical_path = os.path.realpath(
-        rel_toolchain_paths["ghci_lib_path"],
-    )
     if user_ghci_path is not None:
-        script_template = re.sub(
-            pattern="<user_ghci_path>",
-            repl="${{DIR}}/{user_ghci_path} -B{ghci_lib_path}".format(
+        ghci_lib_path = rel_toolchain_paths["ghci_lib_path"]
+
+        if ghci_lib_path:
+            ghci_lib_canonical_path = os.path.realpath(ghci_lib_path)
+
+            replacement="${{DIR}}/{user_ghci_path} -B{ghci_lib_path}".format(
                 user_ghci_path=user_ghci_path,
                 ghci_lib_path=ghci_lib_canonical_path,
-            ),
+            )
+        else:
+            replacement="${{DIR}}/{user_ghci_path}".format(
+                user_ghci_path=user_ghci_path,
+            )
+
+        script_template = re.sub(
+            pattern="<user_ghci_path>",
+            repl=replacement,
             string=script_template,
         )
 

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -11,6 +11,10 @@ load(
     "CxxPlatformInfo",
 )
 load(
+    "@prelude//haskell:toolchain.bzl",
+    "HaskellToolchainLibrary",
+)
+load(
     "@prelude//haskell:library_info.bzl",
     "HaskellLibraryInfo",
     "HaskellLibraryProvider",
@@ -81,6 +85,15 @@ def attr_deps_haskell_link_infos(ctx: AnalysisContext) -> list[HaskellLinkInfo]:
             for d in attr_deps(ctx) + ctx.attrs.template_deps
         ],
     ))
+
+def attr_deps_haskell_toolchain_libraries(ctx: AnalysisContext) -> list[HaskellToolchainLibrary]:
+    return filter(
+        None,
+        [
+            d.get(HaskellToolchainLibrary)
+            for d in attr_deps(ctx) + ctx.attrs.template_deps
+        ],
+    )
 
 # DONT CALL THIS FUNCTION, you want attr_deps_haskell_link_infos instead
 def attr_deps_haskell_link_infos_sans_template_deps(ctx: AnalysisContext) -> list[HaskellLinkInfo]:

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -171,3 +171,34 @@ def get_artifact_suffix(link_style: LinkStyle, enable_profiling: bool, suffix: s
     if enable_profiling:
         artifact_suffix += "-prof"
     return artifact_suffix + suffix
+
+def _source_prefix(source: Artifact, module_name: str) -> str:
+    """Determine the directory prefix of the given artifact, considering that ghc has determined `module_name` for that file."""
+    source_path = paths.replace_extension(source.short_path, "")
+
+    module_name_for_file = src_to_module_name(source_path)
+
+    # assert that source_path (without extension) and its module name have the same length
+    if len(source_path) != len(module_name_for_file):
+        fail("{} should have the same length as {}".format(source_path, module_name_for_file))
+
+    if module_name != module_name_for_file and module_name_for_file.endswith("." + module_name):
+        # N.B. the prefix could have some '.' characters in it, use the source_path to determine the prefix
+        return source_path[0:-len(module_name) - 1]
+
+    return ""
+
+
+def get_source_prefixes(srcs: list[Artifact], module_map: dict[str, str]) -> list[str]:
+    """Determine source prefixes for the given haskell files and a mapping from source file module name to module name."""
+    source_prefixes = {}
+    for path, src in srcs_to_pairs(srcs):
+        if not is_haskell_src(path):
+            continue
+
+        name = src_to_module_name(path)
+        real_name = module_map.get(name)
+        prefix = _source_prefix(src, real_name) if real_name else ""
+        source_prefixes[prefix] = None
+
+    return source_prefixes.keys()

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -41,6 +41,11 @@ HASKELL_EXTENSIONS = [
     ".y",
 ]
 
+HASKELL_BOOT_EXTENSIONS = [
+    ".hs-boot",
+    ".lhs-boot",
+]
+
 # We take a named_set for srcs, which is sometimes a list, sometimes a dict.
 # In future we should only accept a list, but for now, cope with both.
 def srcs_to_pairs(srcs) -> list[(str, Artifact)]:
@@ -52,6 +57,10 @@ def srcs_to_pairs(srcs) -> list[(str, Artifact)]:
 def is_haskell_src(x: str) -> bool:
     _, ext = paths.split_extension(x)
     return ext in HASKELL_EXTENSIONS
+
+def is_haskell_boot(x: str) -> bool:
+    _, ext = paths.split_extension(x)
+    return ext in HASKELL_BOOT_EXTENSIONS
 
 def src_to_module_name(x: str) -> str:
     base, _ext = paths.split_extension(x)


### PR DESCRIPTION
Similar to D54346421WIP

- **Pass correct rpath origin setting to linker on Darwin**
- **Add `cxx_merge_cpreprocessors_actions` function with `AnalysisActions` parameter**
- **Add script to generate target metadata for Haskell**
- **Add ghc wrapper script which writes ABI hash and a deps file**
- **Add `is_haskell_boot` helper function**
- **Add `HaskellToolchainLibrary` provider**
- **Add `haskell_toolchain_library` rule**
- **Add `generate_target_metadata` and `ghc_wrapper` tool targets**
- **make compiler_flags be of arg type (#34)**
- **Add scripts to haskell rules**
- **Allow to declare dependencies for haskell sources manually**
- **Add `get_source_prefixes` helper function**
- **Make `ghci_lib_path` optional in template processor script**
- **Add attributes to haskell rules**
- **Support HaskellToolchainLibs for ide BXL**
- **Make cc toolchain tools optional**
- **Determine haskell dependencies and compile modules according to the dependency graph**

IMPORTANT: Please don't raise pull requests here, but at
[facebook/buck2](https://github.com/facebook/buck2/pulls).

NOTE: this is a PR to get the discussion started on how to incorporate our changes into upstream.

I'll raise a PR at the buck2 repo soonish.

