### PR TITLE
rename prelude//os:ios and prelude//os/constraints:ios to iphoneos

### DIFF
--- a/os/BUCK
+++ b/os/BUCK
@@ -56,9 +56,9 @@ prelude.constraint_value(
 # Rest of Apple's operating systems.
 
 config_setting(
-    name = "ios",
+    name = "iphoneos",
     constraint_values = [
-        "//os/constraints:ios",
+        "//os/constraints:iphoneos",
     ],
     visibility = ["PUBLIC"],
 )

--- a/os/constraints/BUCK
+++ b/os/constraints/BUCK
@@ -36,7 +36,7 @@ constraint_value(
 )
 
 constraint_value(
-    name = "ios",
+    name = "iphoneos",
     constraint_setting = ":os",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
Reviewed By: JakobDegen

Differential Revision: D72425338


